### PR TITLE
Step 2: Searching on List Page

### DIFF
--- a/src/components/PokemonList/PokemonList.tsx
+++ b/src/components/PokemonList/PokemonList.tsx
@@ -1,17 +1,28 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { createUseStyles } from 'react-jss';
 import { useGetPokemons } from '../../hooks/useGetPokemons';
 import { PokemonCard } from '../../components';
 
 export const PokemonList = () => {
   const classes = useStyles();
+  const [searchQuery, setSearchQuery] = useState('');
   const { pokemons, loading } = useGetPokemons();
 
+  const filteredPokemons = pokemons.filter(pkmn =>
+    pkmn.name.toLowerCase().includes(searchQuery.toLowerCase())
+  );
+  
   return (
     <div className={classes.root}>
-      {loading && <div>Loading...</div>}
+      <input
+        type="text"
+        className={classes.searchInput}
+        placeholder="Search Pokemon"
+        value={searchQuery}
+        onChange={(e) => setSearchQuery(e.target.value)}
+      />
       <div className={classes.cardContainer}>
-        {pokemons.map((pkmn, index) => (
+        {filteredPokemons.map((pkmn, index) => (
           <PokemonCard key={index} {...pkmn} />
         ))}
       </div>
@@ -25,6 +36,14 @@ const useStyles = createUseStyles(
       display: 'flex',
       flexDirection: 'column',
       alignItems: 'center',
+    },
+    searchInput: {
+      margin: '16px',
+      padding: '8px',
+      fontSize: '16px',
+      width: '300px',
+      background: '#ffd6ee',
+      color: '#000',
     },
     cardContainer: {
       display: 'flex',


### PR DESCRIPTION
# Assignment part 2:

### Searching on List Page
In order for a user to be able to find a Pokémon quickly, they should be able to search on the Pokémon list page and see filtered results based on their search.

- [x] Implement a search box that filters the list of Pokémon
- [x] Should be case insensitive
- [x] List should only show Pokémon that match the search
- [x] Searching will be client side only and NOT server side** -- The api does not support search

![image](https://github.com/user-attachments/assets/894db746-7fd6-4274-b49a-9e0ba25ee2df)
